### PR TITLE
Update MainStack.cs

### DIFF
--- a/VirtualFinland.Infrastructure/Stacks/MainStack.cs
+++ b/VirtualFinland.Infrastructure/Stacks/MainStack.cs
@@ -23,14 +23,23 @@ public class MainStack : Stack
 
         var vpc = new Vpc($"vf-vpc-{config.Require("environment")}", new VpcArgs()
         {
-            Tags = tags
+            Tags = tags,
+            EnableDnsHostnames = true
+        });
+        
+        var dbSubNetGroup = new SubnetGroup("dbsubnets", new()
+        {
+            SubnetIds = vpc.PrivateSubnetIds, 
         });
 
         this.VpcId = vpc.VpcId;
+        this.VpcName = Output.Create(vpc.GetResourceName());
         this.PublicSubnetIds = vpc.PublicSubnetIds;
         this.PrivateSubnetIds = vpc.PrivateSubnetIds;
     }
     [Output] public Output<string> VpcId { get; set; }
+    
+    [Output] public Output<string> VpcName { get; set; }
 
     [Output] public Output<ImmutableArray<string>> PrivateSubnetIds { get; set; }
     [Output] public Output<ImmutableArray<string>> PublicSubnetIds { get; set; }

--- a/VirtualFinland.Infrastructure/Stacks/MainStack.cs
+++ b/VirtualFinland.Infrastructure/Stacks/MainStack.cs
@@ -26,11 +26,6 @@ public class MainStack : Stack
             Tags = tags,
             EnableDnsHostnames = true
         });
-        
-        var dbSubNetGroup = new SubnetGroup("dbsubnets", new()
-        {
-            SubnetIds = vpc.PrivateSubnetIds, 
-        });
 
         this.VpcId = vpc.VpcId;
         this.VpcName = Output.Create(vpc.GetResourceName());


### PR DESCRIPTION
New Output values and enabled DNS Host names for public access to desired public resources. 

Allows RDS and lambda functions to be used with VPCs properly, it seems that RDS DB instance can't be created without this flag being active.

Also allows public access to lambda function and RDS instances if configured so.