### PR TITLE
Feat/better iam access control

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -20,13 +20,15 @@ jobs:
       - name: Pulumi Configurations Unit Tests
         run: dotnet test ./VirtualFinland.Infrastructure.UnitTests --no-restore
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - uses: pulumi/actions@v3
-        with: 
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: infrastructure-deploy
+      - uses: pulumi/actions@v4
+        with:
           work-dir: ./VirtualFinland.Infrastructure
           command: up
           stack-name: ${{ secrets.PULUMI_ORGANIZATION }}/dev

--- a/.github/workflows/deploy-to-environment.yml
+++ b/.github/workflows/deploy-to-environment.yml
@@ -26,13 +26,15 @@ jobs:
       - name: Pulumi Configurations Unit Tests
         run: dotnet test ./VirtualFinland.Infrastructure.UnitTests --no-restore
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
+        uses: aws-actions/configure-aws-credentials@v2
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      - uses: pulumi/actions@v3
-        with: 
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: infrastructure-deploy
+      - uses: pulumi/actions@v4
+        with:
           work-dir: ./VirtualFinland.Infrastructure
           command: up
           stack-name: ${{ secrets.PULUMI_ORGANIZATION }}/${{ inputs.environment }}

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -21,13 +21,15 @@ jobs:
       - name: Pulumi Configurations Unit Tests
         run: dotnet test ./VirtualFinland.Infrastructure.UnitTests --no-restore
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@v1-node16
-        with: 
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
+        uses: aws-actions/configure-aws-credentials@v2
+        with:
           aws-region: ${{ secrets.AWS_REGION }}
+          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_ID }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
-      
-      - uses: pulumi/actions@v3
+          role-to-assume: ${{ secrets.AWS_ROLE_TO_ASSUME }}
+          role-session-name: infrastructure-test
+
+      - uses: pulumi/actions@v4
         with:
           work-dir: ./VirtualFinland.Infrastructure
           command: preview

--- a/VirtualFinland.Infrastructure/Stacks/Features/KeyRotator.cs
+++ b/VirtualFinland.Infrastructure/Stacks/Features/KeyRotator.cs
@@ -62,7 +62,7 @@ public class KeyRotator
     /// <TODO>
     /// Would need specific policies for each stack
     /// </TODO>
-    public void InitializeStackUpdaterRoleAndPolicy(string environment, InputMap<string> tags)
+    public Role InitializeStackUpdaterRoleAndPolicy(string environment, InputMap<string> tags)
     {
         var currentAwsIdentity = Output.Create(Pulumi.Aws.GetCallerIdentity.InvokeAsync());
 
@@ -121,9 +121,11 @@ public class KeyRotator
             Role = stackUpdaterRole.Name,
             PolicyArn = stackUpdaterPolicy.Arn,
         });
+
+        return stackUpdaterRole;
     }
 
-    public void InitializeRotatorLambdaScheduler(User botUser, string environment, InputMap<string> tags)
+    public void InitializeRotatorLambdaScheduler(User botUser, Role roleToAssume, string environment, InputMap<string> tags)
     {
         //
         // Setup roles and policies
@@ -247,6 +249,7 @@ public class KeyRotator
                 Variables =
                 {
                     { "CICD_BOT_IAM_USER_NAME", botUser.Name },
+                    { "CICD_BOT_IAM_ROLE_TO_ASSUME", roleToAssume.Arn },
                     { "ENVIRONMENT", environment },
                     { "SECRET_NAME", secretManagerName },
                     { "SECRET_REGION", currentRegion },

--- a/VirtualFinland.Infrastructure/Stacks/VFDStack.cs
+++ b/VirtualFinland.Infrastructure/Stacks/VFDStack.cs
@@ -48,6 +48,7 @@ public class VFDStack : Stack
         // Setup key rotator
         var keyRotator = new KeyRotator();
         var botUser = keyRotator.InitializeCICDBotUser(environment, tags);
+        keyRotator.InitializeStackUpdaterRoleAndPolicy(environment, tags);
         keyRotator.InitializeRotatorLambdaScheduler(botUser, environment, tags);
     }
     [Output] public Output<string> VpcId { get; set; }

--- a/VirtualFinland.Infrastructure/Stacks/VFDStack.cs
+++ b/VirtualFinland.Infrastructure/Stacks/VFDStack.cs
@@ -48,8 +48,8 @@ public class VFDStack : Stack
         // Setup key rotator
         var keyRotator = new KeyRotator();
         var botUser = keyRotator.InitializeCICDBotUser(environment, tags);
-        keyRotator.InitializeStackUpdaterRoleAndPolicy(environment, tags);
-        keyRotator.InitializeRotatorLambdaScheduler(botUser, environment, tags);
+        var roleToAssume = keyRotator.InitializeStackUpdaterRoleAndPolicy(environment, tags);
+        keyRotator.InitializeRotatorLambdaScheduler(botUser, roleToAssume, environment, tags);
     }
     [Output] public Output<string> VpcId { get; set; }
 

--- a/VirtualFinland.KeyRotator/Function.cs
+++ b/VirtualFinland.KeyRotator/Function.cs
@@ -76,6 +76,7 @@ public class Function
         var inputObject = new Settings()
         {
             IAMUserName = Environment.GetEnvironmentVariable("CICD_BOT_IAM_USER_NAME") ?? string.Empty,
+            IAMRoleToAssume = Environment.GetEnvironmentVariable("CICD_BOT_IAM_ROLE_TO_ASSUME") ?? string.Empty,
             Environment = input.Environment ?? Environment.GetEnvironmentVariable("ENVIRONMENT") ?? string.Empty,
             SecretName = Environment.GetEnvironmentVariable("SECRET_NAME") ?? string.Empty,
             GitHubOrganizationName = input.GitHubOrganizationName ?? Environment.GetEnvironmentVariable("GITHUB_ORGANIZATION_NAME") ?? "Virtual-Finland-Development",
@@ -109,6 +110,7 @@ public class Function
 public record Settings
 {
     public string IAMUserName { get; set; } = string.Empty;
+    public string IAMRoleToAssume { get; set; } = string.Empty;
     public string Environment { get; set; } = string.Empty;
     public string SecretName { get; set; } = string.Empty;
     public string SecretRegion { get; set; } = string.Empty;

--- a/VirtualFinland.KeyRotator/Services/CredentialsPublisher.cs
+++ b/VirtualFinland.KeyRotator/Services/CredentialsPublisher.cs
@@ -10,6 +10,7 @@ class CredentialsPublisher
     private GitHubApi _gitHubApi;
     private readonly string _githubOrganizationName;
     private readonly string _environment;
+    private readonly string _awsRoleToAssume;
 
     public CredentialsPublisher(GitHubApi gitHubApi, Settings settings, ILambdaLogger logger)
     {
@@ -17,6 +18,7 @@ class CredentialsPublisher
         _logger = logger;
         _githubOrganizationName = settings.GitHubOrganizationName;
         _environment = settings.Environment;
+        _awsRoleToAssume = settings.IAMRoleToAssume;
     }
 
     public async Task PublishAccessKey(AccessKey accessKey)
@@ -42,6 +44,14 @@ class CredentialsPublisher
                 _environment,
                 "AWS_SECRET_ACCESS_KEY",
                 accessKey.SecretAccessKey
+            );
+
+            await _gitHubApi.Secrets.CreateOrUpdateEnvironmentSecret(
+                _githubOrganizationName,
+                repository.Id,
+                _environment,
+                "AWS_ROLE_TO_ASSUME",
+                _awsRoleToAssume
             );
         }
 


### PR DESCRIPTION
- move the admin access from the bot user to an IAM role with an expire time
- on CI/CD pipeline action the bot user assumes the role for the duration of deployment
- could be extended so the bot user and the deployment resources would reside on different AWS accounts etc.